### PR TITLE
Provide connection info on establish for pg

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+        - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
     - uses: actions/checkout@v2
@@ -20,3 +30,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+      env:
+        POSTGRESQL_URL: postgres://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/postgres

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ keywords = ["diesel", "logging", "tracing", "metrics", "database", "mysql", "pos
 
 
 [dependencies]
-diesel = { version = "1.4", features = [], default-features = false }
+diesel = { version = "1.4", features = ["network-address"], default-features = false }
+ipnetwork = "0.16.0"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ diesel feature flags by default to access the underlying C bindings.
 
 ### Levels
 
-All logged traces are currently set to INFO level, potentially this could be
+All logged traces are currently set to DEBUG level, potentially this could be
 changed to a different default or set to be configured by feature flags. At
 them moment this crate is quite new and it's unclear what a sensible default
 would be.
@@ -51,10 +51,13 @@ automatically logged through the `err` directive in the `instrument` macro.
 As statements may contain sensitive information they are currently not recorded
 explicitly, pending finding a way to filter things intelligently.
 
+Similarly connection strings are not recorded in spans as they may contain
+passwords
+
 ### TODO
 
-[ ] Record and log connection information (filtering out sensitive fields)
-[ ] Provide a way of filtering statements, maybe based on regex?
+- [ ] Record and log connection information (filtering out sensitive fields)
+- [ ] Provide a way of filtering statements, maybe based on regex?
 
 
 License: MIT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ diesel feature flags by default to access the underlying C bindings.
 
 ## Levels
 
-All logged traces are currently set to INFO level, potentially this could be
+All logged traces are currently set to DEBUG level, potentially this could be
 changed to a different default or set to be configured by feature flags. At
 them moment this crate is quite new and it's unclear what a sensible default
 would be.
@@ -50,12 +50,18 @@ automatically logged through the `err` directive in the `instrument` macro.
 As statements may contain sensitive information they are currently not recorded
 explicitly, pending finding a way to filter things intelligently.
 
+Similarly connection strings are not recorded in spans as they may contain
+passwords
+
 ## TODO
 
-[ ] Record and log connection information (filtering out sensitive fields)
-[ ] Provide a way of filtering statements, maybe based on regex?
+- [ ] Record and log connection information (filtering out sensitive fields)
+- [ ] Provide a way of filtering statements, maybe based on regex?
 
 */
+#[macro_use]
+extern crate diesel;
+
 pub mod mysql;
 pub mod pg;
 pub mod sqlite;

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -2,17 +2,50 @@ use diesel::connection::{AnsiTransactionManager, Connection, SimpleConnection};
 use diesel::deserialize::{Queryable, QueryableByName};
 use diesel::pg::{Pg, PgConnection, TransactionBuilder};
 use diesel::query_builder::*;
-use diesel::result::{ConnectionResult, QueryResult};
+use diesel::result::{ConnectionError, ConnectionResult, QueryResult};
 use diesel::sql_types::HasSqlType;
-use tracing::instrument;
+use diesel::RunQueryDsl;
+use diesel::{no_arg_sql_function, select};
+use tracing::{debug, instrument};
+
+// https://www.postgresql.org/docs/12/functions-info.html
+// db.name
+no_arg_sql_function!(current_database, diesel::sql_types::Text);
+// net.peer.ip
+no_arg_sql_function!(inet_server_addr, diesel::sql_types::Inet);
+// net.peer.port
+no_arg_sql_function!(inet_server_port, diesel::sql_types::Integer);
+// db.version
+no_arg_sql_function!(version, diesel::sql_types::Text);
+
+#[derive(Queryable, Clone, Debug, PartialEq)]
+struct PgConnectionInfo {
+    current_database: String,
+    inet_server_addr: ipnetwork::IpNetwork,
+    inet_server_port: i32,
+    version: String,
+}
 
 pub struct InstrumentedPgConnection {
     inner: PgConnection,
+    info: PgConnectionInfo,
 }
 
 impl SimpleConnection for InstrumentedPgConnection {
-    #[instrument(fields(db.system="postgresql", otel.kind="client"), skip(self, query), err)]
+    #[instrument(
+        fields(
+            db.name=?self.info.current_database,
+            db.system="postgresql",
+            db.version=?self.info.version,
+            otel.kind="client",
+            net.peer.ip=?self.info.inet_server_addr,
+            net.peer.port=?self.info.inet_server_port,
+        ),
+        skip(self, query),
+        err,
+    )]
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
+        debug!("executing batch query");
         self.inner.batch_execute(query)
     }
 }
@@ -21,21 +54,62 @@ impl Connection for InstrumentedPgConnection {
     type Backend = Pg;
     type TransactionManager = AnsiTransactionManager;
 
-    #[instrument(fields(db.system="postgresql", otel.kind="client"), skip(database_url), err)]
+    #[instrument(
+        fields(
+            db.system="postgresql",
+            otel.kind="client",
+        ),
+        skip(database_url),
+        err,
+    )]
     fn establish(database_url: &str) -> ConnectionResult<InstrumentedPgConnection> {
-        Ok(InstrumentedPgConnection {
-            inner: PgConnection::establish(database_url)?,
-        })
+        debug!("establishing postgresql connection");
+        let conn = PgConnection::establish(database_url)?;
+
+        debug!("querying postgresql connection information");
+        let info: PgConnectionInfo = select((
+            current_database,
+            inet_server_addr,
+            inet_server_port,
+            version,
+        ))
+        .get_result(&conn)
+        .map_err(ConnectionError::CouldntSetupConfiguration)?;
+
+        Ok(InstrumentedPgConnection { inner: conn, info })
     }
 
     #[doc(hidden)]
-    #[instrument(fields(db.system="postgresql", otel.kind="client"), skip(self, query), err)]
+    #[instrument(
+        fields(
+            db.name=?self.info.current_database,
+            db.system="postgresql",
+            db.version=?self.info.version,
+            otel.kind="client",
+            net.peer.ip=?self.info.inet_server_addr,
+            net.peer.port=?self.info.inet_server_port,
+        ),
+        skip(self, query),
+        err,
+    )]
     fn execute(&self, query: &str) -> QueryResult<usize> {
+        debug!("executing query");
         self.inner.execute(query)
     }
 
     #[doc(hidden)]
-    #[instrument(fields(db.system="postgresql", otel.kind="client"), skip(self, source), err)]
+    #[instrument(
+        fields(
+            db.name=?self.info.current_database,
+            db.system="postgresql",
+            db.version=?self.info.version,
+            otel.kind="client",
+            net.peer.ip=?self.info.inet_server_addr,
+            net.peer.port=?self.info.inet_server_port,
+        ),
+        skip(self, source),
+        err,
+    )]
     fn query_by_index<T, U>(&self, source: T) -> QueryResult<Vec<U>>
     where
         T: AsQuery,
@@ -43,38 +117,98 @@ impl Connection for InstrumentedPgConnection {
         Pg: HasSqlType<T::SqlType>,
         U: Queryable<T::SqlType, Pg>,
     {
+        debug!("querying by index");
         self.inner.query_by_index(source)
     }
 
     #[doc(hidden)]
-    #[instrument(fields(db.system="postgresql", otel.kind="client"), skip(self, source), err)]
+    #[instrument(
+        fields(
+            db.name=?self.info.current_database,
+            db.system="postgresql",
+            db.version=?self.info.version,
+            otel.kind="client",
+            net.peer.ip=?self.info.inet_server_addr,
+            net.peer.port=?self.info.inet_server_port,
+        ),
+        skip(self, source),
+        err,
+    )]
     fn query_by_name<T, U>(&self, source: &T) -> QueryResult<Vec<U>>
     where
         T: QueryFragment<Pg> + QueryId,
         U: QueryableByName<Pg>,
     {
+        debug!("querying by name");
         self.inner.query_by_name(source)
     }
 
     #[doc(hidden)]
-    #[instrument(fields(db.system="postgresql", otel.kind="client"), skip(self, source), err)]
+    #[instrument(
+        fields(
+            db.name=?self.info.current_database,
+            db.system="postgresql",
+            db.version=?self.info.version,
+            otel.kind="client",
+            net.peer.ip=?self.info.inet_server_addr,
+            net.peer.port=?self.info.inet_server_port,
+        ),
+        skip(self, source),
+        err,
+    )]
     fn execute_returning_count<T>(&self, source: &T) -> QueryResult<usize>
     where
         T: QueryFragment<Pg> + QueryId,
     {
+        debug!("executing returning count");
         self.inner.execute_returning_count(source)
     }
 
     #[doc(hidden)]
-    #[instrument(fields(db.system="postgresql", otel.kind="client"), skip(self))]
+    #[instrument(
+        fields(
+            db.name=?self.info.current_database,
+            db.system="postgresql",
+            db.version=?self.info.version,
+            otel.kind="client",
+            net.peer.ip=?self.info.inet_server_addr,
+            net.peer.port=?self.info.inet_server_port,
+        ),
+        skip(self),
+    )]
     fn transaction_manager(&self) -> &Self::TransactionManager {
+        debug!("retrieving transaction manager");
         &self.inner.transaction_manager()
     }
 }
 
 impl InstrumentedPgConnection {
-    #[instrument(fields(db.system="postgresql", otel.kind="client"), skip(self))]
+    #[instrument(
+        fields(
+            db.name=?self.info.current_database,
+            db.system="postgresql",
+            db.version=?self.info.version,
+            otel.kind="client",
+            net.peer.ip=?self.info.inet_server_addr,
+            net.peer.port=?self.info.inet_server_port,
+        ),
+        skip(self),
+    )]
     pub fn build_transaction(&self) -> TransactionBuilder {
+        debug!("starting transaction builder");
         self.inner.build_transaction()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_info_on_establish() {
+        InstrumentedPgConnection::establish(
+            &std::env::var("POSTGRESQL_URL").expect("no postgresql env var specified"),
+        )
+        .expect("failed to establish connection or collect info");
     }
 }


### PR DESCRIPTION
Run a query with a new connection on establishing it so that it can be
used to populate information for spans.