### PR TITLE
Correct canonical fields for pg networking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-tracing"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["John Children <john@cambridgequantum.com>"]
 license = "MIT"
 edition = "2018"

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -83,8 +83,8 @@ impl Connection for InstrumentedPgConnection {
         let span = tracing::Span::current();
         span.record("db.name", &info.current_database.as_str());
         span.record("db.version", &info.version.as_str());
-        span.record("db.peer.ip", &format!("{}", info.inet_server_addr).as_str());
-        span.record("db.peer.port", &info.inet_server_port);
+        span.record("net.peer.ip", &format!("{}", info.inet_server_addr).as_str());
+        span.record("net.peer.port", &info.inet_server_port);
 
         Ok(InstrumentedPgConnection { inner: conn, info })
     }


### PR DESCRIPTION
The value of the field name for pg networking was incorrect. This commit
fixes that and bumps the version of the crate.