### PR TITLE
Update ipnetwork bounds to match diesel + fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-tracing"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["John Children <john@cambridgequantum.com>"]
 license = "MIT"
 edition = "2018"
@@ -21,7 +21,7 @@ sqlite = ["diesel/sqlite"]
 
 [dependencies]
 diesel = { version = "1.4", features = ["network-address"], default-features = false }
-ipnetwork = "0.16.0"
+ipnetwork = ">=0.12.2, <0.18.0"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ diesel-tracing = { version = "<version>", features = ["<postgres|mysql|sqlite>"]
 
 ## Fields
 
-Currently the few fields that are recorded are a subset of the OpenTelemetry
+Currently the few fields that are recorded are a subset of the `OpenTelemetry`
 semantic conventions for [databases](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md).
 This was chosen for compatibility with the `tracing-opentelemetry` crate, but
 if it makes sense for other standards to be available this could be set by
@@ -72,6 +72,8 @@ passwords
 - [ ] Provide a way of filtering statements, maybe based on regex?
 
 */
+#![warn(clippy::all, clippy::pedantic)]
+
 #[macro_use]
 extern crate diesel;
 

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -1,7 +1,7 @@
 use diesel::connection::{AnsiTransactionManager, Connection, SimpleConnection};
 use diesel::deserialize::{Queryable, QueryableByName};
 use diesel::mysql::{Mysql, MysqlConnection};
-use diesel::query_builder::*;
+use diesel::query_builder::{AsQuery, QueryFragment, QueryId};
 use diesel::result::{ConnectionResult, QueryResult};
 use diesel::sql_types::HasSqlType;
 use tracing::instrument;
@@ -13,7 +13,9 @@ pub struct InstrumentedMysqlConnection {
 impl SimpleConnection for InstrumentedMysqlConnection {
     #[instrument(fields(db.system="mysql", otel.kind="client"), skip(self, query), err)]
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
-        self.inner.batch_execute(query)
+        self.inner.batch_execute(query)?;
+
+        Ok(())
     }
 }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1,6 +1,6 @@
 use diesel::connection::{AnsiTransactionManager, Connection, SimpleConnection};
 use diesel::deserialize::{Queryable, QueryableByName};
-use diesel::query_builder::*;
+use diesel::query_builder::{AsQuery, QueryFragment, QueryId};
 use diesel::result::Error;
 use diesel::result::{ConnectionResult, QueryResult};
 use diesel::serialize::ToSql;
@@ -15,7 +15,9 @@ pub struct InstrumentedSqliteConnection {
 impl SimpleConnection for InstrumentedSqliteConnection {
     #[instrument(fields(db.system="sqlite", otel.kind="client"), skip(self, query), err)]
     fn batch_execute(&self, query: &str) -> QueryResult<()> {
-        self.inner.batch_execute(query)
+        self.inner.batch_execute(query)?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Match the ipnetwork bounds for diesel to prevent a compile error when two different versions of ipnetwork are used by cargo.

Also fixes various warnings raised by clippy.