### PR TITLE
Update ipnetwork bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2021-06-18
+### Changed
+- Updated ipnetwork bounds to match diesel.
+
 ## [0.1.4] - 2021-03-16
 ### Changed
 - Updated ipnetwork bounds to match diesel.
@@ -29,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial implementation.
 
+[0.1.5]: https://crates.io/crates/diesel-tracing/0.1.5
 [0.1.4]: https://crates.io/crates/diesel-tracing/0.1.4
 [0.1.3]: https://crates.io/crates/diesel-tracing/0.1.3
 [0.1.2]: https://crates.io/crates/diesel-tracing/0.1.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel-tracing"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["John Children <john@cambridgequantum.com>"]
 license = "MIT"
 edition = "2018"
@@ -21,7 +21,7 @@ sqlite = ["diesel/sqlite"]
 
 [dependencies]
 diesel = { version = "1.4", features = ["network-address"], default-features = false }
-ipnetwork = ">=0.12.2, <0.18.0"
+ipnetwork = ">=0.12.2, <0.19.0"
 tracing = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Diesel 1.4.7 allows for 0.18 of ipnetwork so we need to also update our
bounds to match.