### PR TITLE
Implement diesel 2.1 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "diesel-tracing"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["John Children <john@cambridgequantum.com>"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 description = "Connection telemetry middleware for diesel and tracing"
 repository = "https://github.com/CQCL/diesel-tracing"
 readme = "README.md"
@@ -16,13 +16,13 @@ maintenance = { status = "experimental" }
 default = []
 
 mysql = ["diesel/mysql"]
-postgres = ["diesel/postgres"]
+postgres = ["diesel/postgres", "diesel/network-address", "ipnetwork"]
 sqlite = ["diesel/sqlite"]
 
 [dependencies]
-diesel = { version = "1.4", features = ["network-address"], default-features = false }
-ipnetwork = ">=0.12.2, <0.19.0"
+diesel = { version = "2.1", features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"], default-features = false }
+ipnetwork = { version = ">=0.12.2, <0.21.0", optional = true }
 tracing = "0.1"
 
 [dev-dependencies]
-diesel = { version = "1.4", features = ["mysql", "postgres", "sqlite"] }
+diesel = { version = "2.0", features = ["mysql", "postgres", "sqlite"] }

--- a/shell.nix
+++ b/shell.nix
@@ -7,4 +7,6 @@ pkgs.mkShell {
     mysql
     sqlite
   ];
+
+  LD_LIBRARY_PATH = "${pkgs.postgresql.lib}/lib";
 }

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -1,25 +1,28 @@
 use diesel::associations::HasTable;
-use diesel::connection::{AnsiTransactionManager, Connection, SimpleConnection};
-use diesel::deserialize::{Queryable, QueryableByName};
+use diesel::connection::{
+    AnsiTransactionManager, Connection, ConnectionSealed, DefaultLoadingMode, SimpleConnection,
+};
+use diesel::connection::{LoadConnection, TransactionManager};
+use diesel::deserialize::Queryable;
 use diesel::dsl::Update;
-use diesel::pg::{Pg, PgConnection, TransactionBuilder};
-use diesel::query_builder::{AsChangeset, AsQuery, IntoUpdateTarget, QueryFragment, QueryId};
+use diesel::expression::{is_aggregate, MixedAggregates, QueryMetadata, ValidGrouping};
+use diesel::pg::{GetPgMetadataCache, Pg, PgConnection, PgRowByRowLoadingMode, TransactionBuilder};
+use diesel::query_builder::{AsChangeset, IntoUpdateTarget, Query, QueryFragment, QueryId};
 use diesel::query_dsl::{LoadQuery, UpdateAndFetchResults};
 use diesel::result::{ConnectionError, ConnectionResult, QueryResult};
-use diesel::sql_types::HasSqlType;
 use diesel::RunQueryDsl;
-use diesel::{no_arg_sql_function, select};
+use diesel::{select, Table};
 use tracing::{debug, field, instrument};
 
 // https://www.postgresql.org/docs/12/functions-info.html
 // db.name
-no_arg_sql_function!(current_database, diesel::sql_types::Text);
+sql_function!(fn current_database() -> diesel::sql_types::Text);
 // net.peer.ip
-no_arg_sql_function!(inet_server_addr, diesel::sql_types::Inet);
+sql_function!(fn inet_server_addr() -> diesel::sql_types::Inet);
 // net.peer.port
-no_arg_sql_function!(inet_server_port, diesel::sql_types::Integer);
+sql_function!(fn inet_server_port() -> diesel::sql_types::Integer);
 // db.version
-no_arg_sql_function!(version, diesel::sql_types::Text);
+sql_function!(fn version() -> diesel::sql_types::Text);
 
 #[derive(Queryable, Clone, Debug, PartialEq)]
 struct PgConnectionInfo {
@@ -47,13 +50,15 @@ impl SimpleConnection for InstrumentedPgConnection {
         skip(self, query),
         err,
     )]
-    fn batch_execute(&self, query: &str) -> QueryResult<()> {
+    fn batch_execute(&mut self, query: &str) -> QueryResult<()> {
         debug!("executing batch query");
         self.inner.batch_execute(query)?;
 
         Ok(())
     }
 }
+
+impl ConnectionSealed for InstrumentedPgConnection {}
 
 impl Connection for InstrumentedPgConnection {
     type Backend = Pg;
@@ -73,31 +78,27 @@ impl Connection for InstrumentedPgConnection {
     )]
     fn establish(database_url: &str) -> ConnectionResult<InstrumentedPgConnection> {
         debug!("establishing postgresql connection");
-        let conn = PgConnection::establish(database_url)?;
+        let mut conn = PgConnection::establish(database_url)?;
 
         debug!("querying postgresql connection information");
         let info: PgConnectionInfo = select((
-            current_database,
-            inet_server_addr,
-            inet_server_port,
-            version,
+            current_database(),
+            inet_server_addr(),
+            inet_server_port(),
+            version(),
         ))
-        .get_result(&conn)
+        .get_result(&mut conn)
         .map_err(ConnectionError::CouldntSetupConfiguration)?;
 
         let span = tracing::Span::current();
-        span.record("db.name", &info.current_database.as_str());
-        span.record("db.version", &info.version.as_str());
-        span.record(
-            "net.peer.ip",
-            &format!("{}", info.inet_server_addr).as_str(),
-        );
-        span.record("net.peer.port", &info.inet_server_port);
+        span.record("db.name", info.current_database.as_str());
+        span.record("db.version", info.version.as_str());
+        span.record("net.peer.ip", format!("{}", info.inet_server_addr).as_str());
+        span.record("net.peer.port", info.inet_server_port);
 
         Ok(InstrumentedPgConnection { inner: conn, info })
     }
 
-    #[doc(hidden)]
     #[instrument(
         fields(
             db.name=%self.info.current_database,
@@ -107,39 +108,16 @@ impl Connection for InstrumentedPgConnection {
             net.peer.ip=%self.info.inet_server_addr,
             net.peer.port=%self.info.inet_server_port,
         ),
-        skip(self, query),
-        err,
+        skip(self, f),
     )]
-    fn execute(&self, query: &str) -> QueryResult<usize> {
-        debug!("executing query");
-        self.inner.execute(query)
-    }
-
-    #[doc(hidden)]
-    #[instrument(
-        fields(
-            db.name=%self.info.current_database,
-            db.system="postgresql",
-            db.version=%self.info.version,
-            otel.kind="client",
-            net.peer.ip=%self.info.inet_server_addr,
-            net.peer.port=%self.info.inet_server_port,
-        ),
-        skip(self, source),
-        err,
-    )]
-    fn query_by_index<T, U>(&self, source: T) -> QueryResult<Vec<U>>
+    fn transaction<T, E, F>(&mut self, f: F) -> Result<T, E>
     where
-        T: AsQuery,
-        T::Query: QueryFragment<Pg> + QueryId,
-        Pg: HasSqlType<T::SqlType>,
-        U: Queryable<T::SqlType, Pg>,
+        F: FnOnce(&mut Self) -> Result<T, E>,
+        E: From<diesel::result::Error>,
     {
-        debug!("querying by index");
-        self.inner.query_by_index(source)
+        Self::TransactionManager::transaction(self, f)
     }
 
-    #[doc(hidden)]
     #[instrument(
         fields(
             db.name=%self.info.current_database,
@@ -152,37 +130,13 @@ impl Connection for InstrumentedPgConnection {
         skip(self, source),
         err,
     )]
-    fn query_by_name<T, U>(&self, source: &T) -> QueryResult<Vec<U>>
-    where
-        T: QueryFragment<Pg> + QueryId,
-        U: QueryableByName<Pg>,
-    {
-        debug!("querying by name");
-        self.inner.query_by_name(source)
-    }
-
-    #[doc(hidden)]
-    #[instrument(
-        fields(
-            db.name=%self.info.current_database,
-            db.system="postgresql",
-            db.version=%self.info.version,
-            otel.kind="client",
-            net.peer.ip=%self.info.inet_server_addr,
-            net.peer.port=%self.info.inet_server_port,
-        ),
-        skip(self, source),
-        err,
-    )]
-    fn execute_returning_count<T>(&self, source: &T) -> QueryResult<usize>
+    fn execute_returning_count<T>(&mut self, source: &T) -> QueryResult<usize>
     where
         T: QueryFragment<Pg> + QueryId,
     {
-        debug!("executing returning count");
         self.inner.execute_returning_count(source)
     }
 
-    #[doc(hidden)]
     #[instrument(
         fields(
             db.name=%self.info.current_database,
@@ -194,9 +148,82 @@ impl Connection for InstrumentedPgConnection {
         ),
         skip(self),
     )]
-    fn transaction_manager(&self) -> &Self::TransactionManager {
-        debug!("retrieving transaction manager");
-        &self.inner.transaction_manager()
+    fn transaction_state(&mut self) -> &mut Self::TransactionManager {
+        self.inner.transaction_state()
+    }
+}
+
+impl LoadConnection<DefaultLoadingMode> for InstrumentedPgConnection {
+    type Cursor<'conn, 'query> =
+        <PgConnection as LoadConnection<DefaultLoadingMode>>::Cursor<'conn, 'query>
+            where
+                Self: 'conn;
+    type Row<'conn, 'query> =
+        <PgConnection as LoadConnection<DefaultLoadingMode>>::Row<'conn, 'query>
+            where
+                Self: 'conn;
+
+    #[instrument(
+        fields(
+            db.name=%self.info.current_database,
+            db.system="postgresql",
+            db.version=%self.info.version,
+            otel.kind="client",
+            net.peer.ip=%self.info.inet_server_addr,
+            net.peer.port=%self.info.inet_server_port,
+        ),
+        skip(self, source),
+        err,
+    )]
+    fn load<'conn, 'query, T>(
+        &'conn mut self,
+        source: T,
+    ) -> QueryResult<Self::Cursor<'conn, 'query>>
+    where
+        T: Query + QueryFragment<Pg> + QueryId + 'query,
+        Self::Backend: QueryMetadata<T::SqlType>,
+    {
+        <PgConnection as LoadConnection<DefaultLoadingMode>>::load(&mut self.inner, source)
+    }
+}
+
+impl LoadConnection<PgRowByRowLoadingMode> for InstrumentedPgConnection {
+    type Cursor<'conn, 'query> =
+        <PgConnection as LoadConnection<PgRowByRowLoadingMode>>::Cursor<'conn, 'query>
+    where
+        Self: 'conn;
+    type Row<'conn, 'query> =
+        <PgConnection as LoadConnection<PgRowByRowLoadingMode>>::Row<'conn, 'query>
+    where
+        Self: 'conn;
+
+    #[instrument(
+        fields(
+            db.name=%self.info.current_database,
+            db.system="postgresql",
+            db.version=%self.info.version,
+            otel.kind="client",
+            net.peer.ip=%self.info.inet_server_addr,
+            net.peer.port=%self.info.inet_server_port,
+        ),
+        skip(self, source),
+        err,
+    )]
+    fn load<'conn, 'query, T>(
+        &'conn mut self,
+        source: T,
+    ) -> QueryResult<Self::Cursor<'conn, 'query>>
+    where
+        T: Query + QueryFragment<Pg> + QueryId + 'query,
+        Self::Backend: QueryMetadata<T::SqlType>,
+    {
+        <PgConnection as LoadConnection<PgRowByRowLoadingMode>>::load(&mut self.inner, source)
+    }
+}
+
+impl GetPgMetadataCache for InstrumentedPgConnection {
+    fn get_metadata_cache(&mut self) -> &mut diesel::pg::PgMetadataCache {
+        self.inner.get_metadata_cache()
     }
 }
 
@@ -212,18 +239,20 @@ impl InstrumentedPgConnection {
         ),
         skip(self),
     )]
-    pub fn build_transaction(&self) -> TransactionBuilder {
-        debug!("starting transaction builder");
-        self.inner.build_transaction()
+    pub fn build_transaction(&mut self) -> TransactionBuilder<'_, InstrumentedPgConnection> {
+        TransactionBuilder::new(self)
     }
 }
 
-impl<Changes, Output> UpdateAndFetchResults<Changes, Output> for InstrumentedPgConnection
+impl<'b, Changes, Output> UpdateAndFetchResults<Changes, Output> for InstrumentedPgConnection
 where
     Changes: Copy + AsChangeset<Target = <Changes as HasTable>::Table> + IntoUpdateTarget,
-    Update<Changes, Changes>: LoadQuery<PgConnection, Output>,
+    Update<Changes, Changes>: LoadQuery<'b, PgConnection, Output>,
+    <Changes::Table as Table>::AllColumns: ValidGrouping<()>,
+    <<Changes::Table as Table>::AllColumns as ValidGrouping<()>>::IsAggregate:
+        MixedAggregates<is_aggregate::No, Output = is_aggregate::No>,
 {
-    fn update_and_fetch(&self, changeset: Changes) -> QueryResult<Output> {
+    fn update_and_fetch(&mut self, changeset: Changes) -> QueryResult<Output> {
         debug!("updating and fetching changeset");
         self.inner.update_and_fetch(changeset)
     }
@@ -236,7 +265,7 @@ mod tests {
     #[test]
     fn test_get_info_on_establish() {
         InstrumentedPgConnection::establish(
-            &std::env::var("POSTGRESQL_URL").expect("no postgresql env var specified"),
+            &std::env::var("POSTGRESQL_URL").expect("no POSTGRESQL_URL env var specified"),
         )
         .expect("failed to establish connection or collect info");
     }


### PR DESCRIPTION
Implements support for diesel 2.1 and bumps version to 0.2.

Behavior should generally be the same, though the postgresql transaction builder should now work with the instrumented connection properly.