### PR TITLE
Implement MigrationConnection to support migrations

### DIFF
--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -5,12 +5,14 @@ use diesel::connection::{
 };
 use diesel::dsl::{Find, Update};
 use diesel::expression::{is_aggregate, MixedAggregates, QueryMetadata, ValidGrouping};
+use diesel::migration::{MigrationConnection, CREATE_MIGRATIONS_TABLE};
 use diesel::mysql::{Mysql, MysqlConnection};
 use diesel::query_builder::{AsChangeset, IntoUpdateTarget, Query, QueryFragment, QueryId};
 use diesel::query_dsl::methods::{ExecuteDsl, FindDsl};
 use diesel::query_dsl::{LoadQuery, UpdateAndFetchResults};
 use diesel::result::{ConnectionResult, QueryResult};
-use diesel::{Identifiable, Table};
+use diesel::RunQueryDsl;
+use diesel::{sql_query, Identifiable, Table};
 use tracing::{debug, instrument};
 
 pub struct InstrumentedMysqlConnection {
@@ -80,6 +82,12 @@ impl LoadConnection<DefaultLoadingMode> for InstrumentedMysqlConnection {
         Self::Backend: QueryMetadata<T::SqlType>,
     {
         self.inner.load(source)
+    }
+}
+
+impl MigrationConnection for InstrumentedMysqlConnection {
+    fn setup(&mut self) -> QueryResult<usize> {
+        sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
     }
 }
 

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -6,12 +6,13 @@ use diesel::connection::{LoadConnection, TransactionManager};
 use diesel::deserialize::Queryable;
 use diesel::dsl::Update;
 use diesel::expression::{is_aggregate, MixedAggregates, QueryMetadata, ValidGrouping};
+use diesel::migration::{MigrationConnection, CREATE_MIGRATIONS_TABLE};
 use diesel::pg::{GetPgMetadataCache, Pg, PgConnection, PgRowByRowLoadingMode, TransactionBuilder};
 use diesel::query_builder::{AsChangeset, IntoUpdateTarget, Query, QueryFragment, QueryId};
 use diesel::query_dsl::{LoadQuery, UpdateAndFetchResults};
 use diesel::result::{ConnectionError, ConnectionResult, QueryResult};
-use diesel::RunQueryDsl;
 use diesel::{select, Table};
+use diesel::{sql_query, RunQueryDsl};
 use tracing::{debug, field, instrument};
 
 // https://www.postgresql.org/docs/12/functions-info.html
@@ -218,6 +219,12 @@ impl LoadConnection<PgRowByRowLoadingMode> for InstrumentedPgConnection {
         Self::Backend: QueryMetadata<T::SqlType>,
     {
         <PgConnection as LoadConnection<PgRowByRowLoadingMode>>::load(&mut self.inner, source)
+    }
+}
+
+impl MigrationConnection for InstrumentedPgConnection {
+    fn setup(&mut self) -> QueryResult<usize> {
+        sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
     }
 }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -6,6 +6,7 @@ use diesel::connection::{
 use diesel::deserialize::{FromSqlRow, StaticallySizedRow};
 use diesel::dsl::{Find, Update};
 use diesel::expression::{is_aggregate, MixedAggregates, QueryMetadata, ValidGrouping};
+use diesel::migration::{MigrationConnection, CREATE_MIGRATIONS_TABLE};
 use diesel::query_builder::{AsChangeset, IntoUpdateTarget, Query, QueryFragment, QueryId};
 use diesel::query_dsl::methods::{ExecuteDsl, FindDsl};
 use diesel::query_dsl::{LoadQuery, UpdateAndFetchResults};
@@ -13,7 +14,8 @@ use diesel::result::{ConnectionResult, QueryResult};
 use diesel::serialize::ToSql;
 use diesel::sql_types::HasSqlType;
 use diesel::sqlite::{Sqlite, SqliteConnection};
-use diesel::{Identifiable, Table};
+use diesel::RunQueryDsl;
+use diesel::{sql_query, Identifiable, Table};
 use tracing::{debug, instrument};
 
 pub struct InstrumentedSqliteConnection {
@@ -83,6 +85,12 @@ impl LoadConnection<DefaultLoadingMode> for InstrumentedSqliteConnection {
         Self::Backend: QueryMetadata<T::SqlType>,
     {
         self.inner.load(source)
+    }
+}
+
+impl MigrationConnection for InstrumentedSqliteConnection {
+    fn setup(&mut self) -> QueryResult<usize> {
+        sql_query(CREATE_MIGRATIONS_TABLE).execute(self)
     }
 }
 


### PR DESCRIPTION
In my project, I noticed I was able to call `conn.run_pending_migrations()` on the original `SqliteConnection` but not on the `InstrumentedSqliteConnection` from this crate. This PR adds the `MigrationConnection` trait to the instrumented connections to make this possible.

Implementation is copied from https://github.com/diesel-rs/diesel/blob/ce16e91bea0bd85342ff1cf1d683a8b8cb1a6ffc/diesel/src/migration/mod.rs#L201-L223