### PR TITLE
Fix incorrect db.system string on sqlite LoadConnection

### DIFF
--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -73,7 +73,7 @@ impl LoadConnection<DefaultLoadingMode> for InstrumentedSqliteConnection {
         where
             Self: 'conn;
 
-    #[instrument(fields(db.system="mysql", otel.kind="client"), skip(self, source), err)]
+    #[instrument(fields(db.system="sqlite", otel.kind="client"), skip(self, source), err)]
     fn load<'conn, 'query, T>(
         &'conn mut self,
         source: T,


### PR DESCRIPTION
Happened across this issue while scrolling through the `sqlite.rs` file