### PR TITLE
Fix usage of PgMetadataLookup type and missing sql_function import

### DIFF
--- a/src/pg.rs
+++ b/src/pg.rs
@@ -61,7 +61,7 @@ impl MultiConnectionHelper for InstrumentedPgConnection {
     ) -> Option<&mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup> {
         lookup
             .downcast_mut::<Self>()
-            .map(|conn| conn as &mut dyn super::PgMetadataLookup)
+            .map(|conn| conn as &mut dyn diesel::pg::PgMetadataLookup)
     }
 }
 

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -14,7 +14,7 @@ use diesel::query_dsl::{LoadQuery, UpdateAndFetchResults};
 use diesel::r2d2::R2D2Connection;
 use diesel::result::{ConnectionError, ConnectionResult, QueryResult};
 use diesel::{select, Table};
-use diesel::{sql_query, RunQueryDsl};
+use diesel::{sql_query, sql_function, RunQueryDsl};
 use tracing::{debug, field, instrument};
 
 // https://www.postgresql.org/docs/12/functions-info.html


### PR DESCRIPTION
Recently tried to setup using r2d2 with the tracing package and seems like some things got copied incorrectly.

I had the following error:

```
❯ cargo check        
    Checking diesel-tracing v0.2.2
error[E0405]: cannot find trait `PgMetadataLookup` in module `super`
  --> /Users/cmp/.cargo/registry/src/index.crates.io-6f17d22bba15001f/diesel-tracing-0.2.2/src/pg.rs:64:49
   |
64 |             .map(|conn| conn as &mut dyn super::PgMetadataLookup)
   |                                                 ^^^^^^^^^^^^^^^^ not found in `super`
   |
help: consider importing this trait
   |
1  + use diesel::pg::PgMetadataLookup;
   |
help: if you import `PgMetadataLookup`, refer to it directly
   |
64 -             .map(|conn| conn as &mut dyn super::PgMetadataLookup)
64 +             .map(|conn| conn as &mut dyn PgMetadataLookup)
   |

For more information about this error, try `rustc --explain E0405`.
error: could not compile `diesel-tracing` (lib) due to previous error
```

When fixing this issue and confirming that the GHA would build correctly I also found out that `sql_function` seems to have been imported and was preventing the build from succeeding.