### PR TITLE
chore: compile for docs with all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 diesel = { version = "2.0", features = ["mysql", "postgres", "sqlite"] }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true


### PR DESCRIPTION
Add a configuration so all features are shown in docs.rs.
I think this will help people trying to learn how to use the lib from docs.rs