### PR TITLE
Implement support instrumentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ sqlite = ["diesel/sqlite"]
 r2d2 = ["diesel/r2d2"]
 
 [dependencies]
-diesel = { version = "2.1", features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"], default-features = false }
+diesel = { version = "2.2", features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"], default-features = false }
 ipnetwork = { version = ">=0.12.2, <0.21.0", optional = true }
 tracing = "0.1"
 


### PR DESCRIPTION
This pull request addresses a compilation error encountered when using `diesel-tracing` with `diesel` version `2.2.0`.
The error is due to missing implementations for `instrumentation` and `set_instrumentation` methods required by the Connection trait. 

**The compilation error is as follows:**

```log
   Compiling diesel-tracing v0.2.5
error[E0046]: not all trait items implemented, missing: `instrumentation`, `set_instrumentation`
  --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/diesel-tracing-0.2.5/src/pg.rs:91:1
   |
91 | impl Connection for InstrumentedPgConnection {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `instrumentation`, `set_instrumentation` in implementation
   |
   = help: implement the missing item: `fn instrumentation(&mut self) -> &mut (dyn Instrumentation + 'static) { todo!() }`
   = help: implement the missing item: `fn set_instrumentation<impl Instrumentation>(&mut self, _: impl Instrumentation) where impl Instrumentation: Instrumentation { todo!() }`
```

Thank you for your time and consideration.