### PR TITLE
feat: Add a basic diesel::Instrumentation impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ipnetwork = { version = ">=0.12.2, <0.21.0", optional = true }
 tracing = "0.1"
 
 [dev-dependencies]
-diesel = { version = "2.0", features = ["mysql", "postgres", "sqlite"] }
+diesel = { version = "2.2", features = ["mysql", "postgres", "sqlite"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/shell.nix
+++ b/shell.nix
@@ -9,5 +9,5 @@ pkgs.mkShell {
     sqlite
   ];
 
-  LD_LIBRARY_PATH = "${pkgs.postgresql.lib}/lib";
+  LD_LIBRARY_PATH = "${pkgs.postgresql.lib}/lib:${pkgs.libmysqlclient.out}/lib/mariadb:${pkgs.sqlite.out}/lib";
 }

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -94,7 +94,7 @@ impl Connection for InstrumentedMysqlConnection {
 
     #[instrument(fields(db.system="mysql", otel.kind="client"), skip(self, instrumentation))]
     fn set_instrumentation(&mut self, instrumentation: impl Instrumentation) {
-        self.inner.set_instrumentation(instrumentation)
+        self.inner.set_instrumentation(instrumentation);
     }
 }
 

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -207,7 +207,7 @@ impl Connection for InstrumentedPgConnection {
         skip(self, instrumentation)
     )]
     fn set_instrumentation(&mut self, instrumentation: impl Instrumentation) {
-        self.inner.set_instrumentation(instrumentation)
+        self.inner.set_instrumentation(instrumentation);
     }
 }
 

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -97,7 +97,7 @@ impl Connection for InstrumentedSqliteConnection {
 
     #[instrument(fields(db.system="sqlite", otel.kind="client"), skip(self, instrumentation))]
     fn set_instrumentation(&mut self, instrumentation: impl Instrumentation) {
-        self.inner.set_instrumentation(instrumentation)
+        self.inner.set_instrumentation(instrumentation);
     }
 }
 


### PR DESCRIPTION
Adds a very basic implementation for using `tracing` with diesel's `Instrumentation` trait. This implementation just maps `diesel` events directly to `tracing` without much extra information provided beyond that in the events themselves.

In order to bring this in line with the rest of the crate I think there are a few more additions that are required before a release:

- Saving the url used during connection to be included in other events.
- Using opentelemetry semantic conventions for event values.
- Usage documentation and recommendations.